### PR TITLE
Use world_matrix instead of matrix

### DIFF
--- a/matrix_utils.py
+++ b/matrix_utils.py
@@ -293,7 +293,7 @@ def get_camera_projection_matrix(camera, frame, image_format):
     # Matrix to transform points into camera-relative coordinates.
     matrix_world = nuke.math.Matrix4()
     for index in range(16):
-        matrix_world[index] = camera['matrix'].getValueAt(frame, index)
+        matrix_world[index] = camera['world_matrix'].getValueAt(frame, index)
     matrix_world.transpose()
     cam_transform = matrix_world.inverse()
 


### PR DESCRIPTION
This makes it compatible with DummyCam and Stamps,
see https://github.com/adrianpueyo/Stamps/issues/6

`matrix` should be the **identity matrix** but for some strange reason Camera2 and Camera3
returns `world_matrix` when asking for `matrix`.

I'm not sure of the implications for the rest of the codebase, but from testing it **a little** it
seems to not cause any issue.